### PR TITLE
Simplifying Auth Headers: Updating Strategy for Curl Function

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -9,16 +9,7 @@ KOB_APIKEY_INPUT=${kobiton_api_key}
 APP_SUFFIX_INPUT=${kobiton_app_type}
 KOB_APP_ACCESS=${kobiton_app_access}
 
-echo | base64 -w0 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-  # GNU coreutils base64, '-w' supported
-  BASICAUTH=$(echo -n $KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT | base64 -w 0)
-else
-  # Openssl base64, no wrapping by default
-  BASICAUTH=$(echo -n $KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT | base64)
-fi
-
-echo "Using Auth: $BASICAUTH"
+BASICAUTH="$KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT"
 
 if [ -z "$APP_ID_INPUT" ]; then
     JSON="{\"filename\":\"${APP_NAME_INPUT}.${APP_SUFFIX_INPUT}\"}"
@@ -27,7 +18,7 @@ else
 fi
 
 curl --silent -X POST https://api.kobiton.com/v1/apps/uploadUrl \
-    -H "Authorization: Basic $BASICAUTH" \
+    -u $BASICAUTH \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $JSON \
@@ -44,14 +35,14 @@ echo "URL: ${UPLOAD_URL}"
 curl --progress-bar -T "${APP_PATH_INPUT}" \
     -H "Content-Type: application/octet-stream" \
     -H "x-amz-tagging: unsaved=true" \
-    -X PUT "${UPLOAD_URL}"\
-    --verbose
+    -X PUT "${UPLOAD_URL}"
+    # --verbose
 
 echo "Processing: ${KAPPPATH}"
 
 JSON="{\"filename\":\"${APP_NAME_INPUT}.${APP_SUFFIX_INPUT}\",\"appPath\":\"${KAPPPATH}\"}"
 curl -X POST https://api.kobiton.com/v1/apps \
-    -H "Authorization: Basic $BASICAUTH" \
+    -u $BASICAUTH \
     -H 'Content-Type: application/json' \
     -d $JSON \
     -o ".tmp.upload-app-response.json"
@@ -65,7 +56,7 @@ APP_VERSION_ID=$(cat ".tmp.upload-app-response.json" | ack -o --match '(?<=versi
 sleep 30
 
 curl -X GET https://api.kobiton.com/v1/app/versions/$APP_VERSION_ID \
-    -H "Authorization: Basic $BASICAUTH" \
+    -u $BASICAUTH \
     -H "Accept: application/json" \
     -o ".tmp.get-appversion-response.json"
 

--- a/step.sh
+++ b/step.sh
@@ -9,7 +9,14 @@ KOB_APIKEY_INPUT=${kobiton_api_key}
 APP_SUFFIX_INPUT=${kobiton_app_type}
 KOB_APP_ACCESS=${kobiton_app_access}
 
-BASICAUTH=$(echo -n $KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT | base64)
+echo | base64 -w0 > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  # GNU coreutils base64, '-w' supported
+  BASICAUTH=$(echo -n $KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT | base64 -w 0)
+else
+  # Openssl base64, no wrapping by default
+  BASICAUTH=$(echo -n $KOB_USERNAME_INPUT:$KOB_APIKEY_INPUT | base64)
+fi
 
 echo "Using Auth: $BASICAUTH"
 
@@ -37,8 +44,8 @@ echo "URL: ${UPLOAD_URL}"
 curl --progress-bar -T "${APP_PATH_INPUT}" \
     -H "Content-Type: application/octet-stream" \
     -H "x-amz-tagging: unsaved=true" \
-    -X PUT "${UPLOAD_URL}"
-#--verbose
+    -X PUT "${UPLOAD_URL}"\
+    --verbose
 
 echo "Processing: ${KAPPPATH}"
 


### PR DESCRIPTION
Removed base64 encode and used --user option for CURL instead.